### PR TITLE
Migrate runtime to Bun and normalize module specifiers (.js/.jsx), add Bun preload plugin

### DIFF
--- a/@/loader/file/@/createDirectory.js
+++ b/@/loader/file/@/createDirectory.js
@@ -4,7 +4,7 @@ export default target => `
 	import
 		createDirectory
 	from
-		'#@loader/file/action/createDirectory'
+		'#@loader/file/action/createDirectory.js'
 
 	createDirectory('${dirname(target)}')
 `

--- a/@/loader/file/@/loader/index/remove.js
+++ b/@/loader/file/@/loader/index/remove.js
@@ -1,5 +1,5 @@
 export default target => `
-	import remove from '#@loader/file/action/remove'
+	import remove from '#@loader/file/action/remove.js'
 
 	import.meta.hot.prune(remove('${target}'))
 `

--- a/@/loader/file/@/loader/module.js
+++ b/@/loader/file/@/loader/module.js
@@ -42,7 +42,7 @@ export default (condition, extension, getParameters) =>
 						import
 							minify
 						from
-							'#@loader/file/action/minify/${type}'
+							'#@loader/file/action/minify/${type}.js'
 					` : ''}
 
 					${createDirectory(target)}

--- a/@/loader/module/graphics/main.js
+++ b/@/loader/module/graphics/main.js
@@ -1,7 +1,7 @@
 const svg = '<svg'
 
 export default source => `
-	import template from '#@SolidJS/template'
+	import template from '#@SolidJS/template.js'
 
 	export default properties =>
 		template(

--- a/@/style/index.jsx
+++ b/@/style/index.jsx
@@ -2,7 +2,7 @@ import create from './instance'
 
 import main from './css'
 
-import Component from '#@SolidJS/component'
+import Component from '#@SolidJS/component.jsx'
 import {
 	tags
 } from

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 **Effortless Static Site Generation with Flexibility**
 
-Feeling overwhelmed by the static site generator landscape? Refo offers a refreshingly simple and customizable approach **built entirely on Node.js**.
+Feeling overwhelmed by the static site generator landscape? Refo offers a refreshingly simple and customizable approach **powered by Bun**.
 
-Unlike Jekyll, Gatsby, Astro and others, we let you leverage the power of Node.js modules directly. This means you can generate any kind of website you can imagine, all with the flexibility of your favorite Node.js libraries and servers.
+Unlike Jekyll, Gatsby, Astro and others, we let you leverage the power of modern JavaScript modules directly. This means you can generate any kind of website you can imagine, all with the flexibility of your favorite Node.js libraries and servers.
 
 **Key benefits:**
 - **Effortless Development**: Edit your modules and see instant updates thanks to hot reloading.
@@ -36,11 +36,11 @@ Unlike Jekyll, Gatsby, Astro and others, we let you leverage the power of Node.j
 ## Features
 - (**H**ot) **M**odule **R**eloading using [dynohot](https://github.com/braidnetworks/dynohot)
 - JavaScript eXtensible markup language using <a title="SolidJS · Reactive Javascript Library" href="https://www.solidjs.com/"><img alt="SolidJS" src="https://www.solidjs.com/img/logo/with-wordmark/logo.svg" width="" height="18"></a> and [babel-preset-solid](https://github.com/solidjs/solid/tree/main/packages/babel-preset-solid)
-- [Node.js module customization](https://nodejs.org/api/module.html#customization-hooks)
+- [Bun runtime preloading](https://bun.sh/docs/runtime/cli#--preload)
 	- importing SVGs as components
 	- `raw` imports
 	- (Java)Script bundling
-	- Extensionless imports using [specifier-resolution-node](https://github.com/Poyoman39/specifier-resolution-node)
+	- Extensionless imports
 - [Style](https://github.com/kireerik/refo/tree/main/index/module/style)d components using <a title="Emotion" href="https://emotion.sh/docs/introduction"><img alt="Emotion" src="https://raw.githubusercontent.com/emotion-js/emotion/f3b268f7c52103979402da919c9c0dd3f9e0e189/site/public/logo-96x96.png" width="" height="18"> Emotion</a>
 	- [Short class name](https://github.com/kireerik/refo/blob/main/index/module/style/css/getShortName.js)s (like `a`, `b`, `c`, ..., `aa`, `ab`, ...)
 	- [Class name label](https://github.com/kireerik/refo/blob/main/index/module/style/css/getModuleName.js)s in `development` mode using [stack-tracer](https://github.com/bninni/stack-tracer)
@@ -65,20 +65,20 @@ Unlike Jekyll, Gatsby, Astro and others, we let you leverage the power of Node.j
 
 ## Getting Started
 - Initial steps
-	- Install <a title="Node.js" href="https://nodejs.org/en/"><img alt="Node.js" src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Node.js_logo.svg" width="" height="18"></a>, <a title="Fast, disk space efficient package manager | pnpm" href="https://pnpm.io/"><img alt="pnpm" src="https://d33wubrfki0l68.cloudfront.net/aad219b6c931cebb53121dcda794f6180d9e4397/17f34/assets/images/pnpm-standard-79c9dbb2e99b8525ae55174580061e1b.svg" width="" height="18"></a> and <a title="Google Chrome" href="https://www.google.com/chrome/"><img alt="Google Chrome" src="https://upload.wikimedia.org/wikipedia/commons/9/91/Google_Chrome_logo_and_wordmark_%282015%29.png" width="" height="18"></a>.
+	- Install <a title="Bun" href="https://bun.sh/">Bun</a> and <a title="Google Chrome" href="https://www.google.com/chrome/"><img alt="Google Chrome" src="https://upload.wikimedia.org/wikipedia/commons/9/91/Google_Chrome_logo_and_wordmark_%282015%29.png" width="" height="18"></a>.
 	- [Download](https://github.com/kireerik/refo/archive/refs/heads/main.zip) or [clone](x-github-client://openRepo/https://github.com/kireerik/refo) this repository.
 	- Open a command prompt in this folder.
 
 > Install dependencies:
 > ```shell
-> pnpm install
+> bun install
 > ```
 
 > Are you on some kind of Unix based system? Mac? Linux? If so you might want to change the `port` in the `index` module, which is set to `80` which works on Windows. [Superstatic](https://github.com/firebase/superstatic/)'s default is `3474` so you can remove it if you prefer.
 
 Start the server in development mode:
 > ```shell
-> pnpm dev
+> bun run dev
 > ```
 
 Visit http://localhost/ to access the website.
@@ -86,7 +86,7 @@ Visit http://localhost/ to access the website.
 ### Static site generation
 Generate a static site:
 ```shell
-pnpm static
+bun run static
 ```
 Open the `index.html` within the `static` folder to access the website.
 
@@ -94,19 +94,19 @@ Open the `index.html` within the `static` folder to access the website.
 | `import`                                                    |   | generated file |
 | --- | --- | --- |
 | index/                                                      |   | `static`/ |
-| &nbsp;&nbsp; • favicon`.ico` (icon `file` (Node.js module)) |   | &nbsp;&nbsp; • favicon`.ico` |
-| &nbsp;&nbsp; • main`.js`​`.js` (Node.js `module`)            | → | &nbsp;&nbsp; • main`.js` |
-| &nbsp;&nbsp; • index`.html`​`.jsx` (Node.js `module`)        |   | &nbsp;&nbsp; • index`.html` |
-| firebase`.json`​`.js` (Node.js `module`)                     |   | firebase`.json` |
+| &nbsp;&nbsp; • favicon`.ico` (icon `file` (Bun module)) |   | &nbsp;&nbsp; • favicon`.ico` |
+| &nbsp;&nbsp; • main`.js`​`.js` (Bun `module`)            | → | &nbsp;&nbsp; • main`.js` |
+| &nbsp;&nbsp; • index`.html`​`.jsx` (Bun `module`)        |   | &nbsp;&nbsp; • index`.html` |
+| firebase`.json`​`.js` (Bun `module`)                     |   | firebase`.json` |
 
-> The imported `file`s (which have a certain file extension (`ico`, `png`)) (Node.js) modules) copy the files themselves into the `static` folder when the modules are loaded. In module relading mode they remove them if they are not imported anymore.
+> The imported `file`s (which have a certain file extension (`ico`, `png`)) Bun modules) copy the files themselves into the `static` folder when the modules are loaded. In module relading mode they remove them if they are not imported anymore.
 
-> The `default` `export` of (Node.js) `module`s (which have a certain file extension (`js`, `json`, `html`) in their base file name) are written as the contents of the output files (into the `static` folder). The full file names of the output files are the base file names of the (Node.js) `module`s.
+> The `default` `export` of Bun `module`s (which have a certain file extension (`js`, `json`, `html`) in their base file name) are written as the contents of the output files (into the `static` folder). The full file names of the output files are the base file names of the Bun `module`s.
 
 <p align="center">⭐️ Star to support our work!</p>
 
 ## Simple page example source code
-index`.html`​`.jsx` (`import`ed `module`):
+index`.html`​`.jsx` (`import`ed Bun `module`):
 ```Node.js
 import template from '#@SolidJS/template'
 
@@ -167,7 +167,7 @@ You can completely remove the `prefixum` in case you are publishing a `user or a
 
 > Deploy your site to Firebase Hosting:
 > ```shell
-> pnpm deploy
+> bun run deploy
 > ```
 
 ## Contribution

--- a/index/bun/preload.js
+++ b/index/bun/preload.js
@@ -1,0 +1,76 @@
+import {cwd} from 'process'
+import {join} from 'path'
+import {existsSync, statSync} from 'fs'
+
+import {transformSync} from '@babel/core'
+
+const root = cwd()
+
+const extensions = [
+	''
+	, '.js'
+	, '.jsx'
+	, '.json'
+	, '.ico'
+	, '.png'
+	, '.svg'
+]
+
+const indexes = [
+	'/index.js'
+	, '/index.jsx'
+	, '/index.json'
+]
+
+const resolve = path => {
+	for (const extension of extensions) {
+		const candidate = path + extension
+
+		if (existsSync(candidate)) {
+			if (!extension && statSync(candidate).isDirectory())
+				continue
+
+			return candidate
+		}
+	}
+
+	for (const index of indexes) {
+		const candidate = path + index
+
+		if (existsSync(candidate))
+			return candidate
+	}
+
+	return path
+}
+
+Bun.plugin({
+	name: 'refo-aliases-and-jsx'
+	, setup(build) {
+		build.onResolve({filter: /^##@\//}, args => ({
+			path: resolve(join(root, 'source', '@', args.path.slice(4)))
+		}))
+
+		build.onResolve({filter: /^##\//}, args => ({
+			path: resolve(join(root, 'source', args.path.slice(3)))
+		}))
+
+		build.onResolve({filter: /^#@\//}, args => ({
+			path: resolve(join(root, '@', args.path.slice(3)))
+		}))
+
+		build.onLoad({filter: /\.jsx$/}, async args => ({
+			contents:
+				transformSync(
+					await Bun.file(args.path).text()
+					, {
+						presets: [
+							['solid', {generate: 'ssr'}]
+						]
+					}
+				)
+					.code
+			, loader: 'js'
+		}))
+	}
+})

--- a/index/development/index.js
+++ b/index/development/index.js
@@ -6,7 +6,7 @@ global.withModuleReloading = withModuleReloading
 
 global.development = true
 
-await import('..')
+await import('../../source/index.js')
 
 const server = createServer({port: 80}).listen()
 

--- a/index/index.js
+++ b/index/index.js
@@ -2,4 +2,4 @@ import staticDirectory from './@/directory/static'
 
 global.staticDirectory = staticDirectory
 
-await import('##index')
+await import('../source/index.js')

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "solid-js"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,56 +1,37 @@
 {
 	"dependencies": {
-		"image-size": "2.x"
-
-		, "@emotion/css": "11.x"
-		, "@emotion/styled": "11.x"
-
-		, "stack-tracer": "1.x"
-
-		, "@emotion/server": "11.x"
-
-		, "html-minifier-terser": "7.x"
-		, "uglify-js": "3.x"
-
-		, "chrome-finder": "1.x"
-		, "puppeteer-core": "24.x"
-
-		, "specifier-resolution-node": "1.x"
-
-		, "babel-preset-solid": "1.x"
-		, "@babel/core": "7.x"
-
-		, "solid-js": "1.x"
-
-		, "quicklink": "3.x"
-
-		, "lazysizes": "5.x"
-
-		, "markdown-it": "14.x"
-		, "moment": "2.x"
-	}
-	, "devDependencies": {
-		"dynohot": "1.x"
-
-		, "superstatic": "10.x"
-	}
-	, "type": "module"
-	, "imports": {
+		"image-size": "2.x",
+		"@emotion/css": "11.x",
+		"@emotion/styled": "11.x",
+		"stack-tracer": "1.x",
+		"@emotion/server": "11.x",
+		"html-minifier-terser": "7.x",
+		"uglify-js": "3.x",
+		"chrome-finder": "1.x",
+		"puppeteer-core": "24.x",
+		"specifier-resolution-node": "1.x",
+		"babel-preset-solid": "1.x",
+		"@babel/core": "7.x",
+		"solid-js": "1.x",
+		"quicklink": "3.x",
+		"lazysizes": "5.x",
+		"markdown-it": "14.x",
+		"moment": "2.x"
+	},
+	"devDependencies": {
+		"dynohot": "1.x",
+		"superstatic": "10.x"
+	},
+	"type": "module",
+	"imports": {
 		"#@*": "./@/*"
-
-		, "##*": "./source/*"
-	}
-	, "scripts": {
-		"index": "node --import"
-
-		, "static": "pnpm index ./index/loader.js ./index/index.js"
-
-		, "dev": "pnpm index ./index/development/loader.js ./index/development/index.js"
-
-		, "serve": "superstatic serve --port 80"
-
-		, "start": "pnpm static && pnpm serve"
-
-		, "deploy": "pnpm static && firebase deploy"
+	},
+	"scripts": {
+		"index": "bun --preload ./index/bun/preload.js --preload",
+		"static": "bun run index ./index/loader.js ./index/index.js",
+		"dev": "bun run index ./index/development/loader.js ./index/development/index.js",
+		"serve": "bunx superstatic serve --port 80",
+		"start": "bun run static && bun run serve",
+		"deploy": "bun run static && firebase deploy"
 	}
 }

--- a/source/@/icon/index/index.js
+++ b/source/@/icon/index/index.js
@@ -1,4 +1,24 @@
-export {default as LinkedIn     } from './LinkedIn'
-export {default as GitHub       } from './GitHub'
-export {default as StackOverflow} from './StackOverflow'
-export {default as Medium       } from './Medium'
+import template from '#@SolidJS/template.js'
+
+import LinkedInSource from './LinkedIn.svg?raw'
+import GitHubSource from './GitHub.svg?raw'
+import StackOverflowSource from './StackOverflow.svg?raw'
+import MediumSource from './Medium.svg?raw'
+
+const svg = '<svg'
+, namespace = svg + ' xmlns="http://www.w3.org/2000/svg"'
+
+const create = source =>
+	properties =>
+		template(
+			svg + Object.entries(properties).reduce(
+				(result, [name, value]) =>
+					result + ' ' + name + '="' + value + '"'
+			, '')
+			+ source.replace(namespace, '')
+		)
+
+export const LinkedIn = create(LinkedInSource)
+export const GitHub = create(GitHubSource)
+export const StackOverflow = create(StackOverflowSource)
+export const Medium = create(MediumSource)

--- a/source/@/importAll.js
+++ b/source/@/importAll.js
@@ -1,9 +1,36 @@
-import trace from 'stack-tracer'
-
 import {dirname} from 'path'
 
-export default function (names, depth = 0) {
-	const folder = dirname(trace(1 + depth).fileName) + '/'
+import {existsSync} from 'fs'
 
-	names.map(name => import(folder + name))
+import {fileURLToPath} from 'url'
+
+const extension = [
+	''
+	, '.js'
+	, '.jsx'
+	, '.json'
+	, '.ico'
+	, '.png'
+	, '.svg'
+]
+
+const index = [
+	''
+	, '/index.js'
+	, '/index.jsx'
+]
+
+const getPath = base =>
+	[
+		...extension.map(value => base + value)
+		, ...index.map(value => base + value)
+	]
+		.find(path => existsSync(path))
+	?? base
+
+export default async function (names, from) {
+	const folder = dirname(fileURLToPath(from)) + '/'
+
+	for (const name of names)
+		await import(getPath(folder + name))
 }

--- a/source/@/main/header/index.jsx
+++ b/source/@/main/header/index.jsx
@@ -3,12 +3,12 @@ import brand from './brand'
 import page from './page'
 import selected from './selected'
 
-import prefixum from '##index/prefixum'
+import prefixum from '../../../index/prefixum.js'
 
 import title from '../title'
 
-import view from '##index/resume/index/index/view'
-import resumeName from '##index/resume/name'
+import view from '../../../index/resume/index/index/view.js'
+import resumeName from '../../../index/resume/name.js'
 
 export default ({styled, index, resume}) => {
 	const Header = styled.nav`

--- a/source/@/main/index.jsx
+++ b/source/@/main/index.jsx
@@ -2,9 +2,9 @@ import style from './style'
 
 import getHeader from './header'
 
-import template from '#@SolidJS/template'
+import template from '#@SolidJS/template.js'
 
-import prefixum from '##index/prefixum'
+import prefixum from '../../index/prefixum.js'
 
 import brand from './title'
 

--- a/source/@/page.js
+++ b/source/@/page.js
@@ -1,5 +1,5 @@
-import importAll from './importAll'
+import importAll from './importAll.js'
 
-export default function (...names) {
-	importAll(names.map(name => name + '.html'), 1)
+export default async function (from, ...names) {
+	await importAll(names.map(name => name + '.html'), from)
 }

--- a/source/index/.pdf/generate/index.js
+++ b/source/index/.pdf/generate/index.js
@@ -1,6 +1,6 @@
-import full from '##index/resume/full.html/name'
+import full from '../../resume/full.html/name.js'
 
-import resume from '##index/resume/name'
+import resume from '../../resume/name.js'
 
 import {resolve} from 'path'
 

--- a/source/index/.pdf/generate/main.js
+++ b/source/index/.pdf/generate/main.js
@@ -2,9 +2,15 @@ import findChrome from 'chrome-finder'
 
 import {launch} from 'puppeteer-core'
 
-const executablePath = findChrome()
-
 export default async (url, path, format = 'Letter') => {
+	let executablePath
+
+	try {
+		executablePath = findChrome()
+	} catch {
+		return
+	}
+
 	const browser = await launch({executablePath})
 
 	, page = await browser.newPage()

--- a/source/index/.pdf/getName.js
+++ b/source/index/.pdf/getName.js
@@ -1,12 +1,12 @@
-import data from '##index/resume/data'
+import data from '../resume/data.js'
 
-import full from '##index/resume/full.html/name'
+import full from '../resume/full.html/name.js'
 
 import A4 from './A4'
 
-import name from '##index/resume/name'
+import name from '../resume/name.js'
 
-import capitalize from '#@capitalize'
+import capitalize from '#@capitalize.js'
 
 export default (format, version) => [
 	data.basics.name.replaceAll(' ', '')

--- a/source/index/.pdf/index.js
+++ b/source/index/.pdf/index.js
@@ -14,7 +14,7 @@ export default second => {
 		(async () => {
 			const remove =
 				(
-					await import('#@loader/file/action/remove')
+					await import('#@loader/file/action/remove.js')
 				)
 					.default
 

--- a/source/index/index.js
+++ b/source/index/index.js
@@ -1,8 +1,8 @@
-import importAll from '##@/importAll'
+import importAll from '../@/importAll.js'
 
-importAll([
+await importAll([
 	'favicon'
 	, 'main.js'
 	, 'index/index'
 	, 'resume'
-])
+], import.meta.url)

--- a/source/index/index/asset/index.js
+++ b/source/index/index/asset/index.js
@@ -1,3 +1,3 @@
-import './lazysizes.js'
+import './lazysizes.js.js'
 
-import './placeholder'
+import './placeholder.png'

--- a/source/index/index/index.html.jsx
+++ b/source/index/index/index.html.jsx
@@ -1,9 +1,9 @@
-import title from '##@/main/title'
+import title from '../../@/main/title.js'
 
 const slogan = 'A website template for the modern web.'
 , description = 'Powerful developer experience meets lightweight output.'
 
-import use from '#@style'
+import use from '#@style/index.jsx'
 
 const [styling, extract] = use()
 
@@ -12,7 +12,7 @@ style(styling)
 
 import script from './script.js?raw'
 
-import Main from '##@/main'
+import Main from '../../@/main/index.jsx'
 
 export default <Main index {...{
 	title

--- a/source/index/index/index.js
+++ b/source/index/index/index.js
@@ -1,4 +1,5 @@
-import page from '##@/page'
+import page from '../../@/page.js'
 
 import './asset'
-page('index')
+
+await page(import.meta.url, 'index')

--- a/source/index/resume/full.html/index.js
+++ b/source/index/resume/full.html/index.js
@@ -1,3 +1,3 @@
-import index from '../index/index'
+import render from '../index/index.jsx'
 
-export default index('full')
+export default render('full')

--- a/source/index/resume/index.html.js
+++ b/source/index/resume/index.html.js
@@ -1,3 +1,3 @@
-import index from './index/index'
+import render from './index/index.jsx'
 
-export default index()
+export default render()

--- a/source/index/resume/index.js
+++ b/source/index/resume/index.js
@@ -1,3 +1,3 @@
-import page from '##@/page'
+import page from '../../@/page.js'
 
-page('full', 'index')
+await page(import.meta.url, 'full', 'index')

--- a/source/index/resume/index/index.jsx
+++ b/source/index/resume/index/index.jsx
@@ -1,4 +1,4 @@
-import use from '#@style'
+import use from '#@style/index.jsx'
 
 const [styling, extract] = use()
 
@@ -10,9 +10,9 @@ import handle from './handle'
 
 import index from './index/index'
 
-import prefixum from '##index/prefixum'
+import prefixum from '../../prefixum.js'
 
-import Main from '##@/main'
+import Main from '../../../@/main/index.jsx'
 
 import pdf from '../../.pdf'
 

--- a/source/index/resume/index/index/controls.jsx
+++ b/source/index/resume/index/index/controls.jsx
@@ -2,14 +2,14 @@ import view from './view'
 
 import getDocumentName from './documentName'
 
-import prefixum from '##index/prefixum'
+import prefixum from '../../../prefixum.js'
 
 import resume from '../../name'
 import full from '../../full.html/name'
 
-import capitalize from '#@capitalize'
+import capitalize from '#@capitalize.js'
 
-import getName from '##index/.pdf/getName'
+import getName from '../../../.pdf/getName.js'
 
 const or = ' or'
 

--- a/source/index/resume/index/index/documentName.jsx
+++ b/source/index/resume/index/index/documentName.jsx
@@ -1,4 +1,4 @@
-import data from '##index/resume/data'
+import data from '../../data.js'
 
 import full from '../../full.html/name'
 import name from '../../name'

--- a/source/index/resume/index/index/section/awards.jsx
+++ b/source/index/resume/index/index/section/awards.jsx
@@ -1,4 +1,4 @@
-import template from '#@SolidJS/template'
+import template from '#@SolidJS/template.js'
 
 export default awards => awards && <section>
 	<h2>Awards</h2>

--- a/source/index/resume/index/index/section/basics.jsx
+++ b/source/index/resume/index/index/section/basics.jsx
@@ -1,6 +1,6 @@
-import icon from '##@/icon'
+import icon from '../../../../../@/icon/index.jsx'
 
-import template from '#@SolidJS/template'
+import template from '#@SolidJS/template.js'
 
 export default (
 	styling

--- a/source/index/resume/index/index/section/education.jsx
+++ b/source/index/resume/index/index/section/education.jsx
@@ -1,6 +1,6 @@
 import period from '../period'
 
-import template from '#@SolidJS/template'
+import template from '#@SolidJS/template.js'
 
 export default education => education && <section>
 	<h2>Education</h2>

--- a/source/index/resume/index/index/section/publications.jsx
+++ b/source/index/resume/index/index/section/publications.jsx
@@ -1,4 +1,4 @@
-import template from '#@SolidJS/template'
+import template from '#@SolidJS/template.js'
 
 export default publications => publications && <section>
 	<h2>Publications</h2>

--- a/source/index/resume/index/index/section/work.jsx
+++ b/source/index/resume/index/index/section/work.jsx
@@ -1,4 +1,4 @@
-import Component from '#@SolidJS/component'
+import Component from '#@SolidJS/component.jsx'
 
 import period from '../period'
 
@@ -6,7 +6,7 @@ const Summary = ({children}) =>
 	children &&
 		<p class="summary">{children}</p>
 
-import template from '#@SolidJS/template'
+import template from '#@SolidJS/template.js'
 
 const Company = ({as, children, location}) =>
 	<Component {...{as}}>


### PR DESCRIPTION
### Motivation

- Move the project to the Bun runtime and fix import resolution for extensionless and JSX files. 
- Normalize module specifiers by adding explicit `.js`/`.jsx` extensions to ensure consistent loading across Bun. 
- Provide a Bun plugin to handle project aliasing and on-the-fly JSX->JS transforms for SolidJS. 

### Description

- Add a Bun preload plugin at `index/bun/preload.js` that implements alias resolution for `#@/`, `##/`, and `##@/` and transforms `.jsx` files to JS using `@babel/core` with the `solid` preset. 
- Update `package.json` to use Bun-based `scripts`, adjust the `imports` layout and convert script commands to `bun`/`bunx` invocations. 
- Normalize imports across the codebase by appending `.js`/`.jsx` to many `import` specifiers and update internal relative imports to use proper paths (for example `importAll`, `page`, `main`, icons, style and SolidJS template imports). 
- Replace extensionless resource imports with explicit files (e.g. placeholder -> `placeholder.png`, `.js` suffix on asset files) and convert some dynamic loading to `await import` with `import.meta.url` where appropriate. 
- Improve `importAll` to resolve files robustly using `existsSync` and `fileURLToPath` and make it async, and update various modules (icons, resume pages, sections) to use the new import conventions. 
- Make PDF generation robust by handling `chrome-finder` failures gracefully and early-returning if no Chrome executable is found. 
- Update readme and docs to reference Bun and Bun-based commands, and add a `jsconfig.json` for JSX settings. 

### Testing

- No automated tests were included or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e80aaa240832b8862fef17bc41bbe)